### PR TITLE
Add cli support for embkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ package-dir = { "" = "src" }
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[project.scripts]
+embkit = "embkit.__main__:cli"

--- a/src/embkit.egg-info/SOURCES.txt
+++ b/src/embkit.egg-info/SOURCES.txt
@@ -12,8 +12,11 @@ src/embkit/vae.py
 src/embkit.egg-info/PKG-INFO
 src/embkit.egg-info/SOURCES.txt
 src/embkit.egg-info/dependency_links.txt
+src/embkit.egg-info/entry_points.txt
 src/embkit.egg-info/requires.txt
 src/embkit.egg-info/top_level.txt
+src/embkit/commands/__init__.py
+src/embkit/commands/model.py
 src/embkit/constraints/__init__.py
 src/embkit/constraints/network_constraint.py
 src/embkit/estimator/__init__.py

--- a/src/embkit.egg-info/entry_points.txt
+++ b/src/embkit.egg-info/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+embkit = embkit.__main__:cli

--- a/src/embkit/__main__.py
+++ b/src/embkit/__main__.py
@@ -1,14 +1,63 @@
-
-  # my_project/cli.py
 import click
 from .commands import model
 
-@click.group()
-def cli():
-    """A multi-module CLI application."""
-    pass
+# ---- Top-level CLI ----
+@click.group(invoke_without_command=True)
+@click.pass_context
+def cli(ctx):
+    """Embedding Kit CLI.
 
+    Use 'embkit help [COMMAND]' for details on a specific command.
+    """
+    # If no subcommand provided, show the top-level help
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+# Register our commands here
 cli.add_command(model)
 
-if __name__ == '__main__':
+# ---- 'help' command ----
+@cli.command("help", context_settings=dict(ignore_unknown_options=True))
+@click.argument("path", nargs=-1)
+@click.pass_context
+def help_cmd(ctx, path):
+    """
+    Show help for the CLI or a specific command.
+
+    Examples:
+      embkit help
+      embkit help model
+      embkit help model train
+    """
+    # No args -> show top-level help plus a neat command list summary
+    if not path:
+        click.echo(ctx.parent.get_help())
+        click.echo("\nCommands:")
+        # Sorted, with 1-line summaries
+        for name in sorted(cli.commands):
+            cmd = cli.commands[name]
+            summary = (cmd.help or cmd.short_help or "").strip().splitlines()[0]
+            click.echo(f"  {name:15s} {summary}")
+        return
+
+    # Resolve dotted/space-separated path to a nested command
+    cmd = cli
+    info_name = []
+    parent = ctx.parent  # start from top-level context
+    for part in path:
+        if not hasattr(cmd, "get_command"):
+            raise click.UsageError(f"'{ ' '.join(info_name) }' has no subcommands.")
+        nxt_cmd = cmd.get_command(parent, part)
+        if nxt_cmd is None:
+            raise click.UsageError(f"Unknown command: {' '.join(path)}")
+        info_name.append(part)
+        cmd = nxt_cmd
+        parent = click.Context(cmd, info_name=part, parent=parent)
+
+    # Print help for the resolved command
+    click.echo(cmd.get_help(parent))
+
+
+if __name__ == "__main__":
     cli()

--- a/src/embkit/commands/__init__.py
+++ b/src/embkit/commands/__init__.py
@@ -1,0 +1,3 @@
+from .model import model
+
+__all__ = ["model"]

--- a/src/embkit/commands/model.py
+++ b/src/embkit/commands/model.py
@@ -1,0 +1,17 @@
+import click
+import pandas as pd
+from ..vae import VAE
+
+
+model = click.Group(name="model", help="Model commands.")
+
+@model.command()
+@click.argument("input_path", type=click.Path(exists=True, dir_okay=False, readable=True, path_type=str))
+@click.option("--latent", "-l", type=int, default=256, show_default=True, help="Latent dimension size.")
+@click.option("--epochs", "-e", type=int, default=20, show_default=True, help="Training epochs.")
+def train(input_path: str, latent: int, epochs: int):
+    """Train VAE model from a TSV file."""
+    df = pd.read_csv(input_path, sep="\t", index_col=0)
+    vae = VAE(input_dim=df.shape[1], hidden_dim=400, latent_dim=latent)
+    vae.fit(df, epochs=epochs)
+    click.echo("Training complete.")


### PR DESCRIPTION
## Description
This PR adds an `embkit` cli command to the library to easily access the available commands

## Motivation and Context
CLI commands to easily run and use models and related features of the library

## How Has This Been Tested?
Tested using cli locally.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I have updated the documentation accordingly (link here).
- [x] I have tested that this feature locally.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally
