### PR TITLE
Update documentation for vector k in procrustes_scale function

### DIFF
--- a/src/embkit/align.py
+++ b/src/embkit/align.py
@@ -86,10 +86,10 @@ def procrustes(X, Y):
 
 def procrustes_scale(X, Y):
     """
-    Compute the procrustes transformation (R), then compute a factor (k) to rescale the src matrix. 
+    Compute the procrustes transformation (R), then compute scaling factors (k) to rescale the src matrix. 
     
     To apply transformtion:
-    src.dot(R) * k
+    src.dot(R) * k # element-wise multiplication w per-dim scaling factors
 
     
     Args:
@@ -98,7 +98,7 @@ def procrustes_scale(X, Y):
 
     Returns:
         R: The optimal rotation matrix (guaranteed det(R) = +1).
-        k: Scaling factor
+        k: Per-dimension Scaling factors (shape: (N_dims,)), one scaling value per dim
 
     """
     R = procrustes(X,Y)


### PR DESCRIPTION
# Docs: Clarify that procrustes_scale returns vector k, not scalar

The documentation for `procrustes_scale()` in `src/embkit/align.py` suggests that `k` is a scalar value (the more common procrustes approach), when it actually returns a vector of per-dimension scaling factors.

## Changes
Updated docstring (lines 89, 92, 101) to clarify:
- Changed "factor" (singular) to "factors" (plural)
- Added clearer example showing multiplication with per-dimension scaling
- Updated return description to specify shape: one scaling value per dimension

Implementation is unchanged. Only the documentation was misleading. I believe ths covers all mentions of scalar k. 