### PR TITLE
Return Singular values (S) from procrustes to assess alignment (rotat…

### DIFF
--- a/src/embkit/align.py
+++ b/src/embkit/align.py
@@ -67,6 +67,7 @@ def procrustes(X, Y):
 
     Returns:
         R: The optimal rotation matrix (guaranteed det(R) = +1).
+        S: Singular values of X.T @ Y
     """
     assert X.shape == Y.shape
 
@@ -81,7 +82,7 @@ def procrustes(X, Y):
         Vt_corrected[-1, :] *= -1
         R = np.dot(U, Vt_corrected)
 
-    return R
+    return R,S
 
 
 def procrustes_scale(X, Y):
@@ -99,12 +100,13 @@ def procrustes_scale(X, Y):
     Returns:
         R: The optimal rotation matrix (guaranteed det(R) = +1).
         k: Per-dimension Scaling factors (shape: (N_dims,)), one scaling value per dim
+        S: Singular values of X.T @ Y
 
     """
-    R = procrustes(X,Y)
+    R,S = procrustes(X,Y)
     A = np.array(X.dot(R))
     B = np.array(Y)
     numerators = np.sum(A * B, axis=0)
     denominators = np.sum(A * A, axis=0)
     k = np.divide(numerators, denominators, out=np.zeros_like(numerators), where=denominators!=0)
-    return R, k
+    return R, k, S

--- a/tests/preprocessing/test_align.py
+++ b/tests/preprocessing/test_align.py
@@ -88,7 +88,7 @@ class TestAlignmentUtils(unittest.TestCase):
     def test_procrustes_identity(self):
         X = np.eye(3)
         Y = np.eye(3)
-        R = procrustes(X, Y)
+        R, _ = procrustes(X, Y)
         np.testing.assert_array_almost_equal(R, np.eye(3))
 
     def test_procrustes_pure_rotation(self):
@@ -100,7 +100,7 @@ class TestAlignmentUtils(unittest.TestCase):
         rng = np.random.default_rng(0)
         X = rng.standard_normal((60, 2))
         Y = X @ R_true
-        R = procrustes(X, Y)
+        R, _ = procrustes(X, Y)
         np.testing.assert_array_almost_equal(R, R_true, decimal=6)
 
     def test_procrustes_reflection_is_corrected_and_optimal(self):
@@ -115,7 +115,7 @@ class TestAlignmentUtils(unittest.TestCase):
         X = rng.standard_normal((120, 2))
         Y = X @ (R_rot @ F)
 
-        R = procrustes(X, Y)
+        R, _ = procrustes(X, Y)
         self.assertGreater(np.linalg.det(R), 0.0)
         np.testing.assert_array_almost_equal(R @ R.T, np.eye(2), decimal=6)
 
@@ -123,6 +123,21 @@ class TestAlignmentUtils(unittest.TestCase):
         err_R = np.linalg.norm(X @ R - Y)
         err_Rrot = np.linalg.norm(X @ R_rot - Y)
         self.assertLess(err_R, err_Rrot)
+
+    def test_procrustes_singular_values_identity(self):
+        X = np.eye(3)
+        Y = np.eye(3)
+        R, S = procrustes(X, Y)
+        np.testing.assert_array_almost_equal(S, np.ones(3))
+
+    def test_procrustes_singular_values_are_sorted_nonnegative(self):
+        rng = np.random.default_rng(2)
+        X = rng.standard_normal((50, 4))
+        Y = rng.standard_normal((50, 4))
+        R, S = procrustes(X, Y)
+        self.assertEqual(S.shape, (4,))
+        self.assertTrue(np.all(S >= 0))
+        np.testing.assert_array_equal(S, np.sort(S)[::-1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Return Singular values (S) from procrustes and procrustes_scale

The procrustes() function computes `R` via `np.linalg.svd()`, but discards the singular values `S`. These values are helpful for assessing the procrustes solution, specifically in determining the [unconstrained dims when a rank-deficient matrix is passed.](https://github.com/numpy/numpy/blob/7dcee7a469ad1bbfef1cd8980dc18bf5869c5391/numpy/linalg/linalg.py#L1577). 

## Changes
#### [`align.py`](src/embkit/align.py): Changes to procrustes() function(s)
- `procrustes()` now returns `(R,S)` instead of just `R`
- `procrustes_scale()` now returns `(R, k, S)` instead of just `R` and vector `k`

#### [`test_align.py`](tests/preprocessing/test_align.py): Tests Updated/ Added
- 3 Existing procrustes tests were updated to unpack `R, _`
- 2 New tests for `S` (necessary?) 
  - Added `test_procrustes_singular_values_identity`: `S` == [1,1,1] for X=Y=I
  - Added `test_procrustes_singular_values_are_sorted_nonnegative`: shape/non-negativity/descending-order on junk data

#### NOTE: This is a breaking signature change when unpacking procrustes